### PR TITLE
Fix typo in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here the unsubscribe example:
 // Subscribe
 const goodBye = duix.subscribe('user', (newValue, oldValue) => {
   /* ... */
-}));
+});
 
 // Unsubscribe
 goodBye();


### PR DESCRIPTION
There is a typo in the README file (there is an an extra parenthesis)