### PR TITLE
Fix: clone classes

### DIFF
--- a/tests/clone-test.js
+++ b/tests/clone-test.js
@@ -47,4 +47,25 @@ describe('clone', function () {
     // Cloned should not mutate
     expect(cloned.getTime() === NOW).toBeTrue();
   });
+
+
+  it('should clone classes', function () {
+    class CloneTest {
+      test() { return 1; }
+    };
+    const foo = new CloneTest();
+    foo.username = 'aaa';
+
+    const cloned = clone(foo);
+
+    foo.username = 'bbb';
+
+    expect(foo.username === 'bbb').toBeTrue();
+    expect(cloned.username === 'aaa').toBeTrue();
+
+    expect(foo.test()).toBe(1);
+    expect(cloned.test()).toBe(1);
+    expect(foo).toEqual(jasmine.any(CloneTest));
+    expect(cloned instanceof CloneTest).toBeTrue();
+  });
 });

--- a/utils/clone.js
+++ b/utils/clone.js
@@ -35,7 +35,7 @@ function clone(obj) {
 
   // Handle Object
   if (obj instanceof Object) {
-    copy = {};
+    copy = Object.create(Object.getPrototypeOf(obj));
     for (var attr in obj) {
       if (obj.hasOwnProperty(attr)) copy[attr] = clone(obj[attr]);
     }


### PR DESCRIPTION
It appear that the original clone algorithm did not clone classes, but only objects...

See test in tests/clone.js that was not passing.

Have a nice evening